### PR TITLE
add toleration to deployment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,9 @@ matrix:
   include:
     - language: go
       go:
-        - 1.9
         - 1.10
         - 1.11
+        - 1.12
         - tip
       install:
         - go get -u github.com/golang/lint/golint

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ matrix:
   include:
     - language: go
       go:
-        - 1.10
         - 1.11
         - 1.12
         - tip

--- a/charts/elasticsearch/environments/acs/values.yaml
+++ b/charts/elasticsearch/environments/acs/values.yaml
@@ -9,7 +9,7 @@ license:
     repository: mseoss/elasticlicense
     tag: latest
     pullPolicy: Always
-  value:
+  value: 
 
 xpack:
   security: false
@@ -55,6 +55,7 @@ es_master:
     NODE_INGEST: false
     NODE_DATA: false
     NODE_MASTER: true
+  tolerations: []
 
 es_client:
   replicas: "3"
@@ -70,6 +71,7 @@ es_client:
     NODE_INGEST: true
     NODE_DATA: false
     NODE_MASTER: false
+  tolerations: []
 
 es_data:
   replicas: "3"
@@ -87,3 +89,4 @@ es_data:
     NODE_INGEST: false
     NODE_DATA: true
     NODE_MASTER: false
+  tolerations: []

--- a/charts/elasticsearch/templates/es-client.yaml
+++ b/charts/elasticsearch/templates/es-client.yaml
@@ -98,3 +98,7 @@ spec:
       imagePullSecrets:
         - name: {{ .Values.image.pullSecret }}
 {{- end }}
+{{- with .Values.es_client.tolerations }}
+      tolerations:
+{{ toYaml . | indent 8 }}
+{{- end }}

--- a/charts/elasticsearch/templates/es-data-stateful.yaml
+++ b/charts/elasticsearch/templates/es-data-stateful.yaml
@@ -96,6 +96,10 @@ spec:
       imagePullSecrets:
         - name: {{ .Values.image.pullSecret }}
 {{- end }}
+{{- with .Values.es_data.tolerations }}
+      tolerations:
+{{ toYaml . | indent 8 }}
+{{- end }}
   volumeClaimTemplates:
   - metadata:
       name: storage

--- a/charts/elasticsearch/templates/es-master.yaml
+++ b/charts/elasticsearch/templates/es-master.yaml
@@ -95,3 +95,7 @@ spec:
       imagePullSecrets:
         - name: {{ .Values.image.pullSecret }}
 {{- end }}
+{{- with .Values.es_master.tolerations }}
+      tolerations:
+{{ toYaml . | indent 8 }}
+{{- end }}


### PR DESCRIPTION
Hi,

After going through the documentation of Elasticsearch and the README of the official chart (https://github.com/helm/charts/tree/master/stable/elasticsearch) - I understood that it's a good thing to isolate the deployment for the ElasticStack into specific nodes.

If we want to apply that to the charts for AKS, it implies that we need to play with node taints and deployment tolerations.

This PR brings the modifications for adding the tolerations to the deployment. 